### PR TITLE
CS50 링크 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ iOS 면접 준비와 학습을 돕기 위해 구성된 자료 저장소입니다
 
 우선, 기초 지식의 확립이 중요하므로, 면접 질문 학습에 앞서 다음과 같은 권장 학습 자료들을 확인하시길 바랍니다:
 
-1. [CS50](https://www.edwith.org/cs50) - 필수적인 컴퓨터 과학 기초 지식을 배울 수 있는 강좌입니다. (챕터5까지)
-2. [모두를 위한 컴퓨터 과학](https://www.boostcourse.org/cs112/joinLectures/41307) - 자료구조와 알고리즘등 필수적인 개념을 알려주는 강좌입니다.
-3. [Swift 한국어](https://bbiguduk.gitbook.io/swift/) - Swift 언어에 대한 종합적인 이해를 돕는 자료입니다.
-4. [ProGit](https://git-scm.com/book/ko/v2) - Git의 기본 사용법과 원리를 학습할 수 있는 자료입니다.
-5. [leetCode](https://leetcode.com/) - 알고리즘은 프로그래밍에 있어서 빠질수 없는 영역입니다. 꾸준히 많은 문제를 푸시는것이 좋습니다.
+1. [모두를 위한 컴퓨터 과학(CS50)](https://www.boostcourse.org/cs112/joinLectures/41307) - 자료구조와 알고리즘등 필수적인 개념을 알려주는 강좌입니다.
+2. [Swift 한국어](https://bbiguduk.gitbook.io/swift/) - Swift 언어에 대한 종합적인 이해를 돕는 자료입니다.
+3. [ProGit](https://git-scm.com/book/ko/v2) - Git의 기본 사용법과 원리를 학습할 수 있는 자료입니다.
+4. [leetCode](https://leetcode.com/) - 알고리즘은 프로그래밍에 있어서 빠질수 없는 영역입니다. 꾸준히 많은 문제를 푸시는것이 좋습니다.
 
 아래는 Apple의 가이드 문서와 튜토리얼입니다. 지속적으로 업데이트 되고 있으니 한번씩 구경 해보세요.
 


### PR DESCRIPTION
1번 "CS50" 링크가 이전의 edwith링크라 boostcourse홈으로 리다이렉트되고,
2번 "모두를 위한 컴퓨터 과학" 링크가 사실상 이전의 CS50의 챕터 5까지의 내용임을 확인하여 1번을 빼고 넘버링을 다시 하였습니다.
또한 곂치는 내용이라 모두를 위한 컴퓨터 과학뒤에 "(CS50)" 문구를 추가하였습니다.